### PR TITLE
Added recursive_query function, fixes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+.idea/

--- a/fierce.py
+++ b/fierce.py
@@ -227,7 +227,7 @@ def fierce(**kwargs):
     random_subdomain = str(random.randint(1e10, 1e11))
     random_domain = concatenate_subdomains(domain, [random_subdomain])
     wildcard = query(resolver, random_domain, record_type='A')
-    print("Wildcard: {}".format("success" if wildcard else "failure"))
+    print("Wildcard: {}".format(wildcard[0].address if wildcard else "failure"))
 
     if kwargs.get('subdomains'):
         subdomains = kwargs["subdomains"]

--- a/fierce.py
+++ b/fierce.py
@@ -240,7 +240,7 @@ def fierce(**kwargs):
         url = concatenate_subdomains(domain, [subdomain])
         record = query(resolver, url, record_type='A')
 
-        if record is None:
+        if record is None or (record[0].address == wildcard[0].address):
             continue
 
         ip = ipaddress.IPv4Address(record[0].address)


### PR DESCRIPTION
Queries for SOA and NS now recursively search each domain and non-existing domains display an error instead of a stack trace.

Made wildcard handling a bit nicer:
When we find a wildcard user might be interested in seeing the IP. If wildcards exist the brute forcing code should ignore any subdomains that match the wildcard IP, otherwise all subdomains return an IP and the output has too much false positive noise.