### PR TITLE
Small bug in zone_transfer function fixed

### DIFF
--- a/fierce.py
+++ b/fierce.py
@@ -135,7 +135,7 @@ def recursive_query(resolver, domain, record_type='NS'):
 def zone_transfer(address, domain):
     try:
         return dns.zone.from_xfr(dns.query.xfr(address, domain))
-    except (ConnectionError, dns.exception.FormError):
+    except (ConnectionError, dns.exception.FormError, EOFError):
         return None
 
 


### PR DESCRIPTION
Just fixed small bug when port 53 (tcp) is opened but host isn't allowed to connect (tcpwrapped or similar) and connection is closed by remote peer