### PR TITLE
Catch ValueError

### DIFF
--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -127,7 +127,7 @@ def query(resolver, domain, record_type='A', tcp=False):
             return query(resolver, domain, record_type, tcp=tcp)
 
         return None
-    except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.Timeout):
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.exception.Timeout, ValueError):
         return None
 
 


### PR DESCRIPTION
Sometimes, Python's DNS library will get confused and throw ValueError when the DNS server doesn't respond (this catch-all exception handler might be the case: https://github.com/rthalley/dnspython/blob/master/dns/inet.py#L116; at least that's what I'm seeing in my stack traces). When this happens, Fierce crashes with a stack trace instead of continuing like it would with a normal timeout. This should fix it.