### PR TITLE
Remove shebang

### DIFF
--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import concurrent.futures
 import functools


### PR DESCRIPTION
There is an `entry_points` in `setup.py` already. Thus, the shebang is not needed.