### PR TITLE
Handle malformed subdomains more gracefully

### DIFF
--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -358,7 +358,7 @@ def fierce(**kwargs):
         try:
             url = concatenate_subdomains(domain, [subdomain])
         except dns.exception.DNSException:
-            print("Error occured for subdomain: "+str(subdomain)+". Skipping.")
+            print("Error occured for subdomain: " + str(subdomain) + ". Skipping.")
             continue
 
         record = query(resolver, url, record_type='A', tcp=kwargs["tcp"])

--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -357,10 +357,11 @@ def fierce(**kwargs):
     for subdomain in subdomains:
         try:
             url = concatenate_subdomains(domain, [subdomain])
-            record = query(resolver, url, record_type='A', tcp=kwargs["tcp"])
-        except:
+        except dns.exception.DNSException:
             print("Error occured for subdomain: "+str(subdomain)+". Skipping.")
             continue
+
+        record = query(resolver, url, record_type='A', tcp=kwargs["tcp"])
 
         if record is None or record.rrset is None:
             continue

--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -355,8 +355,12 @@ def fierce(**kwargs):
     unvisited = unvisited_closure()
 
     for subdomain in subdomains:
-        url = concatenate_subdomains(domain, [subdomain])
-        record = query(resolver, url, record_type='A', tcp=kwargs["tcp"])
+        try:
+            url = concatenate_subdomains(domain, [subdomain])
+            record = query(resolver, url, record_type='A', tcp=kwargs["tcp"])
+        except:
+            print("Error occured for subdomain: "+str(subdomain)+". Skipping.")
+            continue
 
         if record is None or record.rrset is None:
             continue


### PR DESCRIPTION
This prevents the program from exiting when a malformed subdomain is encountered (e.g. too long, empty, ., ..), this is a common scenario when dealing with wordlists (e.g. https://github.com/danielmiessler/SecLists/blob/master/Discovery/DNS/shubs-stackoverflow.txt)