### PR TITLE
Updating to dnspython 2.2.1 and patching #40

### DIFF
--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -6,6 +6,7 @@ import functools
 import http.client
 import ipaddress
 import itertools
+from logging import warning
 import multiprocessing
 import os
 import pprint
@@ -13,6 +14,7 @@ import random
 import socket
 import sys
 import time
+import warnings
 
 import dns.exception
 import dns.name
@@ -321,6 +323,9 @@ def fierce(**kwargs):
         master = query(resolver, soa_mname, record_type='A', tcp=kwargs["tcp"])
         master_address = master[0].address
         print("SOA: {} ({})".format(soa_mname, master_address))
+        if master_address == "127.0.0.1":
+            warning("Master address is localhost, switching to provided resolver (%s) instead" % resolver.nameservers[0])
+            master_address = resolver.nameservers[0]
     else:
         print("SOA: failure")
         fatal("Failed to lookup NS/SOA, Domain does not exist")

--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -110,7 +110,7 @@ def concatenate_subdomains(domain, subdomains):
 
 def query(resolver, domain, record_type='A', tcp=False):
     try:
-        resp = resolver.query(domain, record_type, raise_on_no_answer=False, tcp=tcp)
+        resp = resolver.resolve(qname=domain, rdtype=record_type, raise_on_no_answer=False, tcp=True)
         if resp.response.answer:
             return resp
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dnspython==1.16.0
+dnspython==2.2.1


### PR DESCRIPTION
I update the dnspython to the latest to date (2.2.1) and patched a warning following the update.
The PR is to fix a bug when the DNS server provided points to itself, fierce cannot perform a zone transfert. It shouldn't happen a lot in production and zone transfert enabled are not common, but still could happen   