### PR TITLE
Fix `NoneType` error when querying SOA records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project adheres to [CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-
 ### Fixed
 
 - Add proper error handling for cases when SOA record is None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,98 +1,145 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This project adheres to [CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.5.1] - 2023-07-30
+
+### Fixed
+
+- Add proper error handling for cases when SOA record is None
+
+### Removed
+
+- Official Python 3.6 support
+- Official Python 3.7 support
+
 ## [1.5.0] - 2021-12-05
+
 ### Added
+
 - Official Python 3.9 support
 - Official Python 3.10 support
 
 ### Changed
+
 - Improved various error handling
 
 ### Removed
+
 - Official Python 3.5 support
 
 ## [1.4.0] - 2019-11-07
+
 ### Added
+
 - Official Python 3.8 support
 - The --tcp flag to use TCP instead of UDP DNS queries
 
 ### Removed
+
 - Official Python 3.4 support, it's EOL
 
 ## [1.3.0] - 2019-05-15
+
 ### Changed
+
 - Print out all A records for wildcard, not just first one
 
 ### Added
+
 - Filter out subdomains with an A record matching a wildcard A record
 - Official Python 3.7 support
 
 ### Fixed
+
 - Prevent out of bounds error when expanding IPs near 0.0.0.0 or 255.255.255.255
 
 ## [1.2.2] - 2018-04-24
+
 ### Changed
+
 - Python 3 is now a requirement when installing via setup.py (including pip)
 - The README markdown is now included in the package's long description
 
 ## [1.2.1] - 2018-03-01
+
 ### Changed
+
 - Nearby IP reverse queries are now multithread, which improves performance significantly
 - Updated development dependencies
 - Subdomain lists use package_data instead of data_files
 
 ### Added
+
 - Gracefully handle users exiting the script with Ctrl+C
 - Gracefully handle incorrect file or IP range arguments
 
 ### Removed
+
 - Official Python 3.3 support, it's EOL
 
 ## [1.2.0] - 2017-05-07
+
 ### Added
+
 - Official Python 3.6 support
 
 ### Fixed
+
 - Handling of subdomains specified that are actually FQDNs
 - Gracefully handling timeouts when querying nameservers
 - Gracefully handling timeouts when querying zone transfers
 
 ## [1.1.5] - 2017-01-08
+
 ### Fixed
+
 - Fixed bug with CNAME records pointing to an A record without an associated IP
 - Fixed bug with connections being closed by remote peer
 
 ## [1.1.4] - 2016-08-30
+
 ### Fixed
+
 - Undo a PR that was breaking everything
 
 ## [1.1.3] - 2016-08-30
+
 ### Fixed
+
 - Fixed a subdomain concatenation bug
 
 ## [1.1.2] - 2016-08-15
+
 ### Changed
+
 - PyPI is absolutely ridiculous and needs a new version to upload the same package
 
 ## [1.1.1] - 2016-08-11
+
 ### Changed
+
 - Better error handling when making network connections
 - PEP8 formatting
 
 ## [1.1.0] - 2016-05-16
+
 ### Added
+
 - Intelligent subdomain file searching
 - PyPI classifiers
 
 ### Changed
+
 - Using more modern setuptools instead of distutils
 - Small README improvements
 
 ## [1.0.0] - 2016-05-08
+
 ### Added
+
 - Initial release of Fierce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project adheres to [CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [1.5.1] - 2023-07-30
 
 ### Fixed
 

--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -319,8 +319,12 @@ def fierce(**kwargs):
     if soa:
         soa_mname = soa[0].mname
         master = query(resolver, soa_mname, record_type='A', tcp=kwargs["tcp"])
-        master_address = master[0].address
-        print("SOA: {} ({})".format(soa_mname, master_address))
+        if master:
+            master_address = master[0].address
+            print("SOA: {} ({})".format(soa_mname, master_address))
+        else:
+            print("SOA: failure")
+            fatal("Failed to lookup NS/SOA, Domain does not exist")
     else:
         print("SOA: failure")
         fatal("Failed to lookup NS/SOA, Domain does not exist")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(long_description_filename) as fd:
 
 setup(
     name='fierce',
-    version='1.5.1',
+    version='1.5.0',
     description='A DNS reconnaissance tool for locating non-contiguous IP space.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(long_description_filename) as fd:
 
 setup(
     name='fierce',
-    version='1.5.0',
+    version='1.5.1',
     description='A DNS reconnaissance tool for locating non-contiguous IP space.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -38,8 +38,6 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     install_requires=install_requires,
     tests_require=tests_require,
-    python_requires='>=3.0',
+    python_requires='>=3.8',
     entry_points={
         'console_scripts': [
             'fierce = fierce.fierce:main',


### PR DESCRIPTION
Hey there 👋🏻 

In this PR, I have made changes to `fierce` function to fix `NoneType` error whenever SOA query return `None`. After applying the patch the tool will gradually shutdown and print a proper error message.  I have tested the changes locally, and they work perfectly.

Example of the error:
```bash
fierce --domain belgiantrain.be

NS: ns2.belgiantrain.be. ns1.belgiantrain.be.
Traceback (most recent call last):
  File "/Users/user/Projects/fierce/.venv/bin/fierce", line 33, in <module>
    sys.exit(load_entry_point('fierce', 'console_scripts', 'fierce')())
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Projects/fierce/fierce/fierce.py", line 491, in main
    fierce(**vars(args))
  File "/Users/user/Projects/fierce/fierce/fierce.py", line 322, in fierce
    master_address = master[0].address
                     ~~~~~~^^^
TypeError: 'NoneType' object is not subscriptable
```

I would love to hear your feedback on these changes. Please let me know if there's anything you'd like me to modify or improve. I'm here to make any necessary adjustments to ensure this contribution aligns with the project's standards.

Cheers,
Max 👨🏻‍💻 
