### PR TITLE
Fix Deprecation Warning: resolver.query()

### DIFF
--- a/fierce/fierce.py
+++ b/fierce/fierce.py
@@ -101,7 +101,7 @@ def concatenate_subdomains(domain, subdomains):
 
 def query(resolver, domain, record_type='A', tcp=False):
     try:
-        resp = resolver.query(domain, record_type, raise_on_no_answer=False, tcp=tcp)
+        resp = resolver.resolve(domain, record_type, raise_on_no_answer=False, tcp=tcp)
         if resp.response.answer:
             return resp
 


### PR DESCRIPTION
Summary of Changes:
- Replaced deprecated dns.resolver.Resolver.query() method with the updated dns.resolver.Resolver.resolve() method introduced in dnspython 2.0.0.
- Ensures compatibility with the latest library version and prevents DeprecationWarning.
- Updated all DNS lookup calls to use the new resolve() API.

Reason for Changes:
- query() is deprecated and may no longer function in future versions of dnspython.
- resolve() provides enhanced functionality and better alignment with DNS standards.

This update keeps the codebase up-to-date with modern practices and avoids potential issues caused by deprecated methods.